### PR TITLE
This is the home page with posts and pagination 

### DIFF
--- a/lib/firebase.js
+++ b/lib/firebase.js
@@ -40,7 +40,7 @@ export const storage = firebase.storage();
 
 
 
-/**`
+/**'
  * Converts a firestore document to millisecond-precise (cant be JSON)
  * @param  {DocumentSnapshot} doc
  */
@@ -53,3 +53,6 @@ export const storage = firebase.storage();
     updatedAt: data.updatedAt.toMillis(),
   };
 }
+
+
+export const fromMillis = firebase.firestore.Timestamp.fromMillis;

--- a/pages/index.js
+++ b/pages/index.js
@@ -28,6 +28,33 @@ export default function Home(props) {
 
   const [postsEnd, setPostsEnd] = useState(false);
 
+  const getMorePosts = async () => {
+    setLoading(true);
+    // get last post in the array to run paginated query
+    const last = posts[posts.length - 1];
+
+    // if createdAt value is a timestamp, convert to date, otherwise use date
+    const cursor = typeof last.createdAt === 'number' ? fromMillis(last.createdAt) : last.createdAt;
+
+    const query = firestore
+      .collectionGroup('posts')
+      .where('published', '==', true)
+      .orderBy('createdAt', 'desc')
+      .startAfter(cursor)
+      .limit(LIMIT);
+
+
+    const newPosts = (await query.get()).docs.map((doc) => doc.data());
+
+  // update post to existing list of posts
+    setPosts(posts.concat(newPosts));
+    setLoading(false);
+
+    if (newPosts.length < LIMIT) {
+      setPostsEnd(true);
+    }
+  };
+
   return (
     <main>
       <PostFeed posts={posts} />

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,9 +1,8 @@
-import Head from "next/head";
-import Image from "next/image";
-import styles from "../styles/Home.module.css";
+import PostFeed from '../components/PostFeed';
+import Loader from '../components/Loader';
+import { firestore, fromMillis, postToJSON } from '../lib/firebase';
 
-import toast from "react-hot-toast";
-
+import { useState } from 'react';
 // # of posts to grab for each paginated batch on firebase
 // its the max # of posts to query per page
 const LIMIT = 1;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,33 +1,45 @@
-import Head from 'next/head'
-import Image from 'next/image'
-import styles from '../styles/Home.module.css'
+import Head from "next/head";
+import Image from "next/image";
+import styles from "../styles/Home.module.css";
 
-import toast from "react-hot-toast"
+import toast from "react-hot-toast";
 
 // # of posts to grab for each paginated batch on firebase
 // its the max # of posts to query per page
 const LIMIT = 1;
 
-  export async function getServerSideProps(context) {
-    const postsQuery = firestore
-      // get collection no matter where it is located, it could be after a user's uid
-      .collectionGroup('posts')
-      .where('published', '==', true)
-      .orderBy('createdAt', 'desc')
-      .limit(LIMIT);
-  
-    const posts = (await postsQuery.get()).docs.map(postToJSON);
-  
-    return {
-      props: { posts }, // will be passed to the page component as props
-    };
-  }
+export async function getServerSideProps(context) {
+  const postsQuery = firestore
+    // get collection no matter where it is located, it could be after a user's uid
+    .collectionGroup("posts")
+    .where("published", "==", true)
+    .orderBy("createdAt", "desc")
+    .limit(LIMIT);
 
+  const posts = (await postsQuery.get()).docs.map(postToJSON);
+
+  return {
+    props: { posts }, // will be passed to the page component as props
+  };
+}
 
 export default function Home(props) {
+  const [posts, setPosts] = useState(props.posts);
+  const [loading, setLoading] = useState(false);
+
+  const [postsEnd, setPostsEnd] = useState(false);
+
   return (
     <main>
+      <PostFeed posts={posts} />
 
+      {!loading && !postsEnd && (
+        <button onClick={getMorePosts}>Load more</button>
+      )}
+
+      <Loader show={loading} />
+
+      {postsEnd && "You have reached the end!"}
     </main>
-  )
+  );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -4,13 +4,30 @@ import styles from '../styles/Home.module.css'
 
 import toast from "react-hot-toast"
 
-export default function Home() {
+// # of posts to grab for each paginated batch on firebase
+// its the max # of posts to query per page
+const LIMIT = 1;
+
+  export async function getServerSideProps(context) {
+    const postsQuery = firestore
+      // get collection no matter where it is located, it could be after a user's uid
+      .collectionGroup('posts')
+      .where('published', '==', true)
+      .orderBy('createdAt', 'desc')
+      .limit(LIMIT);
+  
+    const posts = (await postsQuery.get()).docs.map(postToJSON);
+  
+    return {
+      props: { posts }, // will be passed to the page component as props
+    };
+  }
+
+
+export default function Home(props) {
   return (
-    <div>
-      <h1>Home, Welcome</h1>
-      <button onClick={() => toast.success('Testing some toast msg')}>
-        Toast Test 
-      </button>
-    </div>
+    <main>
+
+    </main>
   )
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -33,6 +33,7 @@ export default function Home(props) {
     <main>
       <PostFeed posts={posts} />
 
+      {/* if post is not loading or not at the end, then show a button to load more posts */}
       {!loading && !postsEnd && (
         <button onClick={getMorePosts}>Load more</button>
       )}


### PR DESCRIPTION
Added pagination to posts with function to retrieve the server props of posts, then passing it to the state in the frontend. Another function to retrieve more posts and a loader indicator while posts are bring fetched from the server. For now, the max number of posts to fetch is one, but once the dummy data is synced with firestore, I'll integrate it.